### PR TITLE
Enable review tap to show popup

### DIFF
--- a/lib/screens/search_screen.dart
+++ b/lib/screens/search_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import '../widgets/search_bar.dart';
 import '../widgets/search_results_section.dart';
+import '../widgets/review_popup.dart';
 
 class SearchPage extends StatefulWidget {
   const SearchPage({Key? key}) : super(key: key);
@@ -31,14 +32,15 @@ class _SearchPageState extends State<SearchPage> {
       final snapshot =
           await FirebaseFirestore.instance.collection('reviews').get();
       setState(() {
-        _allReviews =
-            snapshot.docs.map((doc) {
-              final data = doc.data();
-              data['name'] = data['meal'] ?? '';
-              data['rating'] =
-                  data['rating'] != null ? (data['rating'] as num).toInt() : 0;
-              return data;
-            }).toList();
+        _allReviews = snapshot.docs.map((doc) {
+          final data = {...doc.data()};
+          data['name'] = data['meal'] ?? '';
+          data['rating'] =
+              data['rating'] != null ? (data['rating'] as num).toInt() : 0;
+          data['snapshot'] = doc;
+          data['docId'] = doc.id;
+          return data;
+        }).toList();
       });
     } catch (e) {
       print('Error fetching reviews: $e');
@@ -150,6 +152,12 @@ class _SearchPageState extends State<SearchPage> {
                     setState(() {
                       _selectedRating = value ?? 0;
                     });
+                  },
+                  onItemTap: (item) {
+                    final doc = item['snapshot'];
+                    if (doc is QueryDocumentSnapshot) {
+                      showReviewPopup(context, doc);
+                    }
                   },
                 ),
                 const SizedBox(height: 12),

--- a/lib/widgets/result_item.dart
+++ b/lib/widgets/result_item.dart
@@ -4,35 +4,43 @@ class ResultItem extends StatelessWidget {
   final String name;
   final int rating;
   final bool showStars;
+  final VoidCallback? onTap;
 
   const ResultItem({
     Key? key,
     required this.name,
     required this.rating,
     this.showStars = true, // defaults to true if not provided
+    this.onTap,
   }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    return Padding(
-      padding: EdgeInsets.symmetric(horizontal: 10, vertical: 4),
-      child: Row(
-        children: [
-          Text('- $name', style: TextStyle(color: Colors.white, fontSize: 14)),
-          SizedBox(width: 5),
-          // Conditionally display the star rating.
-          if (showStars)
-            Row(
-              children: List.generate(
-                5,
-                (index) => Icon(
-                  index < rating ? Icons.star : Icons.star_border,
-                  size: 14,
-                  color: Colors.yellow,
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        onTap: onTap,
+        child: Padding(
+          padding: EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+          child: Row(
+            children: [
+              Text('- $name', style: TextStyle(color: Colors.white, fontSize: 14)),
+              SizedBox(width: 5),
+              // Conditionally display the star rating.
+              if (showStars)
+                Row(
+                  children: List.generate(
+                    5,
+                    (index) => Icon(
+                      index < rating ? Icons.star : Icons.star_border,
+                      size: 14,
+                      color: Colors.yellow,
+                    ),
+                  ),
                 ),
-              ),
-            ),
-        ],
+            ],
+          ),
+        ),
       ),
     );
   }

--- a/lib/widgets/search_results_section.dart
+++ b/lib/widgets/search_results_section.dart
@@ -10,6 +10,7 @@ class SearchResultsSection extends StatelessWidget {
   final bool enableRatingFilter;
   final int selectedRating;
   final ValueChanged<int?>? onRatingChanged;
+  final ValueChanged<Map<String, dynamic>>? onItemTap;
 
   const SearchResultsSection({
     Key? key,
@@ -20,6 +21,7 @@ class SearchResultsSection extends StatelessWidget {
     this.enableRatingFilter = false,
     this.selectedRating = 0,
     this.onRatingChanged,
+    this.onItemTap,
   }) : super(key: key);
 
   @override
@@ -81,6 +83,9 @@ class SearchResultsSection extends StatelessWidget {
                             // You might pass 0 or any value since ResultItem will check showStars.
                             rating: showStars ? (item['rating'] ?? 0) : 0,
                             showStars: showStars, // Pass the flag to ResultItem
+                            onTap: onItemTap != null
+                                ? () => onItemTap!(item)
+                                : null,
                           ),
                         )
                         .toList(),


### PR DESCRIPTION
## Summary
- persist review document snapshots for search results
- add optional tap handling to search result items
- invoke review popup when tapping review search results

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d6e56891bc8327ae10072cfba29307